### PR TITLE
Push the publish conversion down to the intra-process manager

### DIFF
--- a/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
+++ b/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
@@ -174,8 +174,9 @@ public:
    */
   template<
     typename MessageT,
-    typename Alloc = std::allocator<void>,
-    typename Deleter = std::default_delete<MessageT>>
+    typename Alloc,
+    typename Deleter = std::default_delete<MessageT>
+  >
   void
   do_intra_process_publish(
     uint64_t intra_process_publisher_id,
@@ -241,8 +242,9 @@ public:
 
   template<
     typename MessageT,
-    typename Alloc = std::allocator<void>,
-    typename Deleter = std::default_delete<MessageT>>
+    typename Alloc,
+    typename Deleter = std::default_delete<MessageT>
+  >
   std::shared_ptr<const MessageT>
   do_intra_process_publish_and_return_shared(
     uint64_t intra_process_publisher_id,
@@ -340,7 +342,8 @@ private:
   template<
     typename MessageT,
     typename Alloc,
-    typename Deleter>
+    typename Deleter
+  >
   void
   add_shared_msg_to_buffers(
     std::shared_ptr<const MessageT> message,
@@ -394,8 +397,9 @@ private:
 
   template<
     typename MessageT,
-    typename Alloc = std::allocator<void>,
-    typename Deleter = std::default_delete<MessageT>>
+    typename Alloc,
+    typename Deleter
+  >
   void
   add_owned_msg_to_buffers(
     std::unique_ptr<MessageT, Deleter> message,

--- a/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
+++ b/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
@@ -241,16 +241,27 @@ public:
   }
 
   template<
+    typename MessageT,
+    typename T,
     typename PublishedType,
+    typename ROSMessageType,
     typename Alloc,
+    typename ROSMessageTypeAllocatorTraits,
+    typename ROSMessageTypeAllocator,
+    typename ROSMessageTypeDeleter,
     typename Deleter = std::default_delete<PublishedType>
   >
   std::shared_ptr<const PublishedType>
   do_intra_process_publish_and_return_shared(
     uint64_t intra_process_publisher_id,
     std::unique_ptr<PublishedType, Deleter> message,
-    typename allocator::AllocRebind<PublishedType, Alloc>::allocator_type & allocator)
+    typename allocator::AllocRebind<PublishedType, Alloc>::allocator_type & allocator,
+    ROSMessageTypeAllocator & ros_message_type_allocator,
+    ROSMessageTypeDeleter & ros_message_type_deleter)
   {
+    (void)ros_message_type_allocator;
+    (void)ros_message_type_deleter;
+
     using MessageAllocTraits = allocator::AllocRebind<PublishedType, Alloc>;
     using MessageAllocatorT = typename MessageAllocTraits::allocator_type;
 

--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -537,11 +537,13 @@ protected:
       throw std::runtime_error("cannot publish msg which is a null pointer");
     }
 
-    return ipm->template do_intra_process_publish_and_return_shared<PublishedType,
-             AllocatorT>(
+    return ipm->template do_intra_process_publish_and_return_shared<MessageT, T, PublishedType,
+             ROSMessageType, AllocatorT, ROSMessageTypeAllocatorTraits, ROSMessageTypeAllocator, ROSMessageTypeDeleter>(
       intra_process_publisher_id_,
       std::move(msg),
-      published_type_allocator_);
+      published_type_allocator_,
+      ros_message_type_allocator_,
+      ros_message_type_deleter_);
   }
 
   template<typename T>
@@ -562,11 +564,13 @@ protected:
       throw std::runtime_error("cannot publish msg which is a null pointer");
     }
 
-    ipm->template do_intra_process_publish_and_return_shared<PublishedType,
-             AllocatorT>(
+    ipm->template do_intra_process_publish_and_return_shared<MessageT, T, PublishedType,
+             ROSMessageType, AllocatorT, ROSMessageTypeAllocatorTraits, ROSMessageTypeAllocator, ROSMessageTypeDeleter>(
       intra_process_publisher_id_,
       std::move(msg),
-      published_type_allocator_);
+      published_type_allocator_,
+      ros_message_type_allocator_,
+      ros_message_type_deleter_);
 
     // TODO(clalancette): We are doing the conversion at least twice; inside of
     // IntraProcessManager::do_intra_process_publish_and_return_shared(), and here.

--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -520,11 +520,7 @@ protected:
 
 
   template<typename T>
-  typename
-  std::enable_if_t<
-    rosidl_generator_traits::is_message<T>::value &&
-    std::is_same<T, ROSMessageType>::value, std::shared_ptr<const ROSMessageType>
-  >
+  std::shared_ptr<const ROSMessageType>
   do_intra_process_publish_and_return_shared(
     std::unique_ptr<PublishedType, PublishedTypeDeleter> msg)
   {
@@ -544,41 +540,6 @@ protected:
       published_type_allocator_,
       ros_message_type_allocator_,
       ros_message_type_deleter_);
-  }
-
-  template<typename T>
-  typename
-  std::enable_if_t<
-    rclcpp::TypeAdapter<MessageT>::is_specialized::value &&
-    std::is_same<T, PublishedType>::value, std::shared_ptr<const ROSMessageType>
-  >
-  do_intra_process_publish_and_return_shared(
-    std::unique_ptr<PublishedType, PublishedTypeDeleter> msg)
-  {
-    auto ipm = weak_ipm_.lock();
-    if (!ipm) {
-      throw std::runtime_error(
-              "intra process publish called after destruction of intra process manager");
-    }
-    if (!msg) {
-      throw std::runtime_error("cannot publish msg which is a null pointer");
-    }
-
-    ipm->template do_intra_process_publish_and_return_shared<MessageT, T, PublishedType,
-             ROSMessageType, AllocatorT, ROSMessageTypeAllocatorTraits, ROSMessageTypeAllocator, ROSMessageTypeDeleter>(
-      intra_process_publisher_id_,
-      std::move(msg),
-      published_type_allocator_,
-      ros_message_type_allocator_,
-      ros_message_type_deleter_);
-
-    // TODO(clalancette): We are doing the conversion at least twice; inside of
-    // IntraProcessManager::do_intra_process_publish_and_return_shared(), and here.
-    // We should just do it in the IntraProcessManager and return it here.
-    auto unique_ros_msg = this->create_ros_message_unique_ptr();
-    rclcpp::TypeAdapter<MessageT>::convert_to_ros_message(*msg, *unique_ros_msg);
-
-    return unique_ros_msg;
   }
 
   /// Return a new unique_ptr using the ROSMessageType of the publisher.


### PR DESCRIPTION
That is, we delay the conversion until the call to `IntraProcessManager::do_intra_process_publish_and_return_shared`.  This still ends up in double-conversion, but at least it is hidden away in the IntraProcessManager for now.  We'll have to revisit this to make it do less work later.