### PR TITLE
Clarify the template types

### DIFF
--- a/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
+++ b/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
@@ -209,8 +209,11 @@ public:
       // None of the buffers require ownership, so we promote the pointer
       std::shared_ptr<PublishedType> msg = std::move(message);
 
-      this->template add_shared_msg_to_buffers<MessageT, PublishedType, ROSMessageType, Alloc, Deleter, ROSMessageTypeAllocatorTraits>(
-        msg, sub_ids.take_shared_subscriptions, ros_message_type_allocator);
+      this->template add_shared_msg_to_buffers<MessageT, PublishedType, ROSMessageType, Alloc,
+          Deleter, ROSMessageTypeAllocatorTraits, ROSMessageTypeAllocator>(
+        msg,
+        sub_ids.take_shared_subscriptions,
+        ros_message_type_allocator);
     } else {
       if (sub_ids.take_shared_subscriptions.size() <= 1) {
         // There is at maximum 1 buffer that does not require ownership.
@@ -227,7 +230,9 @@ public:
           sub_ids.take_ownership_subscriptions.begin(),
           sub_ids.take_ownership_subscriptions.end());
 
-        this->template add_owned_msg_to_buffers<MessageT, PublishedType, ROSMessageType, Alloc, Deleter, ROSMessageTypeAllocatorTraits>(
+        this->template add_owned_msg_to_buffers<MessageT, PublishedType, ROSMessageType, Alloc,
+            Deleter, ROSMessageTypeAllocatorTraits, ROSMessageTypeAllocator, ROSMessageTypeDeleter,
+            PublishedTypeAllocator>(
           std::move(message),
           concatenated_vector,
           published_type_allocator,
@@ -238,10 +243,19 @@ public:
         // for the buffers that do not require ownership
         auto shared_msg = std::allocate_shared<PublishedType, PublishedTypeAllocator>(published_type_allocator, *message);
 
-        this->template add_shared_msg_to_buffers<MessageT, PublishedType, ROSMessageType, Alloc, Deleter, ROSMessageTypeAllocatorTraits>(
-          shared_msg, sub_ids.take_shared_subscriptions, ros_message_type_allocator);
-        this->template add_owned_msg_to_buffers<MessageT, PublishedType, ROSMessageType, Alloc, Deleter, ROSMessageTypeAllocatorTraits>(
-          std::move(message), sub_ids.take_ownership_subscriptions, published_type_allocator, ros_message_type_allocator, ros_message_type_deleter);
+        this->template add_shared_msg_to_buffers<MessageT, PublishedType, ROSMessageType, Alloc,
+            Deleter, ROSMessageTypeAllocatorTraits, ROSMessageTypeAllocator>(
+          shared_msg,
+          sub_ids.take_shared_subscriptions,
+          ros_message_type_allocator);
+        this->template add_owned_msg_to_buffers<MessageT, PublishedType, ROSMessageType, Alloc, Deleter,
+            ROSMessageTypeAllocatorTraits, ROSMessageTypeAllocator, ROSMessageTypeDeleter,
+            PublishedTypeAllocator>(
+          std::move(message),
+          sub_ids.take_ownership_subscriptions,
+          published_type_allocator,
+          ros_message_type_allocator,
+          ros_message_type_deleter);
       }
     }
   }
@@ -252,10 +266,11 @@ public:
     typename PublishedType,
     typename ROSMessageType,
     typename Alloc,
+    typename Deleter,
     typename ROSMessageTypeAllocatorTraits,
     typename ROSMessageTypeAllocator,
     typename ROSMessageTypeDeleter,
-    typename Deleter = std::default_delete<PublishedType>
+    typename PublishedTypeAllocator
   >
   typename
   std::enable_if_t<
@@ -265,16 +280,10 @@ public:
   do_intra_process_publish_and_return_shared(
     uint64_t intra_process_publisher_id,
     std::unique_ptr<PublishedType, Deleter> message,
-    typename allocator::AllocRebind<PublishedType, Alloc>::allocator_type & allocator,
+    PublishedTypeAllocator & published_type_allocator,
     ROSMessageTypeAllocator & ros_message_type_allocator,
     ROSMessageTypeDeleter & ros_message_type_deleter)
   {
-    (void)ros_message_type_allocator;
-    (void)ros_message_type_deleter;
-
-    using MessageAllocTraits = allocator::AllocRebind<PublishedType, Alloc>;
-    using MessageAllocatorT = typename MessageAllocTraits::allocator_type;
-
     std::shared_lock<std::shared_timed_mutex> lock(mutex_);
 
     auto publisher_it = pub_to_subs_.find(intra_process_publisher_id);
@@ -291,26 +300,32 @@ public:
       // If there are no owning, just convert to shared.
       std::shared_ptr<PublishedType> shared_msg = std::move(message);
       if (!sub_ids.take_shared_subscriptions.empty()) {
-        this->template add_shared_msg_to_buffers<MessageT, PublishedType, ROSMessageType, Alloc, Deleter, ROSMessageTypeAllocatorTraits>(
-          shared_msg, sub_ids.take_shared_subscriptions, ros_message_type_allocator);
+        this->template add_shared_msg_to_buffers<MessageT, PublishedType, ROSMessageType, Alloc,
+            Deleter, ROSMessageTypeAllocatorTraits, ROSMessageTypeAllocator>(
+          shared_msg,
+          sub_ids.take_shared_subscriptions,
+          ros_message_type_allocator);
       }
       return shared_msg;
     } else {
       // Construct a new shared pointer from the message for the buffers that
       // do not require ownership and to return.
-      auto shared_msg = std::allocate_shared<PublishedType, MessageAllocatorT>(allocator, *message);
+      auto shared_msg = std::allocate_shared<PublishedType, PublishedTypeAllocator>(published_type_allocator, *message);
 
       if (!sub_ids.take_shared_subscriptions.empty()) {
-        this->template add_shared_msg_to_buffers<MessageT, PublishedType, ROSMessageType, Alloc, Deleter, ROSMessageTypeAllocatorTraits>(
+        this->template add_shared_msg_to_buffers<MessageT, PublishedType, ROSMessageType, Alloc,
+            Deleter, ROSMessageTypeAllocatorTraits, ROSMessageTypeAllocator>(
           shared_msg,
           sub_ids.take_shared_subscriptions,
           ros_message_type_allocator);
       }
 
-      this->template add_owned_msg_to_buffers<MessageT, PublishedType, ROSMessageType, Alloc, Deleter, ROSMessageTypeAllocatorTraits>(
+      this->template add_owned_msg_to_buffers<MessageT, PublishedType, ROSMessageType, Alloc,
+          Deleter, ROSMessageTypeAllocatorTraits, ROSMessageTypeAllocator, ROSMessageTypeDeleter,
+          PublishedTypeAllocator>(
         std::move(message),
         sub_ids.take_ownership_subscriptions,
-        allocator,
+        published_type_allocator,
         ros_message_type_allocator,
         ros_message_type_deleter);
 
@@ -324,10 +339,11 @@ public:
     typename PublishedType,
     typename ROSMessageType,
     typename Alloc,
+    typename Deleter,
     typename ROSMessageTypeAllocatorTraits,
     typename ROSMessageTypeAllocator,
     typename ROSMessageTypeDeleter,
-    typename Deleter = std::default_delete<PublishedType>
+    typename PublishedTypeAllocator
   >
   typename
   std::enable_if_t<
@@ -337,7 +353,7 @@ public:
   do_intra_process_publish_and_return_shared(
     uint64_t intra_process_publisher_id,
     std::unique_ptr<PublishedType, Deleter> message,
-    typename allocator::AllocRebind<PublishedType, Alloc>::allocator_type & allocator,
+    PublishedTypeAllocator & published_type_allocator,
     ROSMessageTypeAllocator & ros_message_type_allocator,
     ROSMessageTypeDeleter & ros_message_type_deleter)
   {
@@ -345,9 +361,6 @@ public:
     ROSMessageTypeAllocatorTraits::construct(ros_message_type_allocator, ptr);
     auto unique_ros_msg = std::unique_ptr<ROSMessageType, ROSMessageTypeDeleter>(ptr, ros_message_type_deleter);
     rclcpp::TypeAdapter<MessageT>::convert_to_ros_message(*message, *unique_ros_msg);
-
-    using MessageAllocTraits = allocator::AllocRebind<PublishedType, Alloc>;
-    using MessageAllocatorT = typename MessageAllocTraits::allocator_type;
 
     std::shared_lock<std::shared_timed_mutex> lock(mutex_);
 
@@ -365,25 +378,31 @@ public:
       // If there are no owning, just convert to shared.
       std::shared_ptr<PublishedType> shared_msg = std::move(message);
       if (!sub_ids.take_shared_subscriptions.empty()) {
-        this->template add_shared_msg_to_buffers<MessageT, PublishedType, ROSMessageType, Alloc, Deleter, ROSMessageTypeAllocatorTraits>(
-          shared_msg, sub_ids.take_shared_subscriptions, ros_message_type_allocator);
+        this->template add_shared_msg_to_buffers<MessageT, PublishedType, ROSMessageType, Alloc,
+            Deleter, ROSMessageTypeAllocatorTraits, ROSMessageTypeAllocator>(
+          shared_msg,
+          sub_ids.take_shared_subscriptions,
+          ros_message_type_allocator);
       }
     } else {
       // Construct a new shared pointer from the message for the buffers that
       // do not require ownership and to return.
-      auto shared_msg = std::allocate_shared<PublishedType, MessageAllocatorT>(allocator, *message);
+      auto shared_msg = std::allocate_shared<PublishedType, PublishedTypeAllocator>(published_type_allocator, *message);
 
       if (!sub_ids.take_shared_subscriptions.empty()) {
-        this->template add_shared_msg_to_buffers<MessageT, PublishedType, ROSMessageType, Alloc, Deleter, ROSMessageTypeAllocatorTraits>(
+        this->template add_shared_msg_to_buffers<MessageT, PublishedType, ROSMessageType, Alloc,
+            Deleter, ROSMessageTypeAllocatorTraits, ROSMessageTypeAllocator>(
           shared_msg,
           sub_ids.take_shared_subscriptions,
           ros_message_type_allocator);
       }
 
-      this->template add_owned_msg_to_buffers<MessageT, PublishedType, ROSMessageType, Alloc, Deleter, ROSMessageTypeAllocatorTraits>(
+      this->template add_owned_msg_to_buffers<MessageT, PublishedType, ROSMessageType, Alloc,
+          Deleter, ROSMessageTypeAllocatorTraits, ROSMessageTypeAllocator, ROSMessageTypeDeleter,
+          PublishedTypeAllocator>(
         std::move(message),
         sub_ids.take_ownership_subscriptions,
-        allocator,
+        published_type_allocator,
         ros_message_type_allocator,
         ros_message_type_deleter);
     }
@@ -446,13 +465,14 @@ private:
     typename ROSMessageType,
     typename Alloc,
     typename Deleter,
-    typename ROSMessageTypeAllocatorTraits
+    typename ROSMessageTypeAllocatorTraits,
+    typename ROSMessageTypeAllocator
   >
   void
   add_shared_msg_to_buffers(
     std::shared_ptr<const PublishedType> message,
     std::vector<uint64_t> subscription_ids,
-    typename ROSMessageTypeAllocatorTraits::allocator_type & ros_message_type_allocator)
+    ROSMessageTypeAllocator & ros_message_type_allocator)
   {
     for (auto id : subscription_ids) {
       auto subscription_it = subscriptions_.find(id);
@@ -505,15 +525,18 @@ private:
     typename ROSMessageType,
     typename Alloc,
     typename Deleter,
-    typename ROSMessageTypeAllocatorTraits
+    typename ROSMessageTypeAllocatorTraits,
+    typename ROSMessageTypeAllocator,
+    typename ROSMessageTypeDeleter,
+    typename PublishedTypeAllocator
   >
   void
   add_owned_msg_to_buffers(
     std::unique_ptr<PublishedType, Deleter> message,
     std::vector<uint64_t> subscription_ids,
-    typename allocator::AllocRebind<PublishedType, Alloc>::allocator_type & allocator,
-    typename ROSMessageTypeAllocatorTraits::allocator_type & ros_message_type_allocator,
-    typename allocator::Deleter<typename ROSMessageTypeAllocatorTraits::allocator_type, ROSMessageType> & ros_message_type_deleter)
+    PublishedTypeAllocator & published_type_allocator,
+    ROSMessageTypeAllocator & ros_message_type_allocator,
+    ROSMessageTypeDeleter & ros_message_type_deleter)
   {
 
     std::cout << "add owned msg to buffers" << std::endl;
@@ -556,7 +579,6 @@ private:
             std::cout << "ROSMessage TypeAdapted Subscription" << std::endl;
 
             if constexpr (rclcpp::TypeAdapter<MessageT>::is_specialized::value) {
-              using ROSMessageTypeDeleter = typename allocator::Deleter<typename ROSMessageTypeAllocatorTraits::allocator_type, ROSMessageType>;
               auto ptr = ROSMessageTypeAllocatorTraits::allocate(ros_message_type_allocator, 1);
               ROSMessageTypeAllocatorTraits::construct(ros_message_type_allocator, ptr);
               auto ros_msg = std::unique_ptr<ROSMessageType, ROSMessageTypeDeleter>(ptr, ros_message_type_deleter);
@@ -571,8 +593,8 @@ private:
                 // Copy the message since we have additional subscriptions to serve
                 MessageUniquePtr copy_message;
                 Deleter deleter = message.get_deleter();
-                auto ptr = MessageAllocTraits::allocate(allocator, 1);
-                MessageAllocTraits::construct(allocator, ptr, *message);
+                auto ptr = MessageAllocTraits::allocate(published_type_allocator, 1);
+                MessageAllocTraits::construct(published_type_allocator, ptr, *message);
                 copy_message = MessageUniquePtr(ptr, deleter);
 
                 ros_message_subscription->provide_intra_process_message(std::move(copy_message));
@@ -589,8 +611,8 @@ private:
             // Copy the message since we have additional subscriptions to serve
             MessageUniquePtr copy_message;
             Deleter deleter = message.get_deleter();
-            auto ptr = MessageAllocTraits::allocate(allocator, 1);
-            MessageAllocTraits::construct(allocator, ptr, *message);
+            auto ptr = MessageAllocTraits::allocate(published_type_allocator, 1);
+            MessageAllocTraits::construct(published_type_allocator, ptr, *message);
             copy_message = MessageUniquePtr(ptr, deleter);
 
             subscription->provide_intra_process_data(std::move(copy_message));

--- a/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
+++ b/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
@@ -448,7 +448,7 @@ private:
       auto subscription_base = subscription_it->second.lock();
       if (subscription_base) {
         auto subscription = std::dynamic_pointer_cast<
-          rclcpp::experimental::SubscriptionIntraProcessBuffer<PublishedType, Alloc, Deleter>
+          rclcpp::experimental::SubscriptionIntraProcessBuffer<MessageT, PublishedType, Alloc, Deleter>
           >(subscription_base);
         if (nullptr == subscription) {
 
@@ -459,7 +459,7 @@ private:
           if (nullptr == ros_message_subscription) {
             throw std::runtime_error(
                     "failed to dynamic cast SubscriptionIntraProcessBase to "
-                    "SubscriptionIntraProcessBuffer<PublishedType, Alloc, Deleter>, which "
+                    "SubscriptionIntraProcessBuffer<MessageT, PublishedType, Alloc, Deleter>, which "
                     "can happen when the publisher and subscription use different "
                     "allocator types, which is not supported");
           } else {
@@ -518,7 +518,7 @@ private:
         std::cout << "Typed Subscription" << std::endl;
 
         auto subscription = std::dynamic_pointer_cast<
-          rclcpp::experimental::SubscriptionIntraProcessBuffer<PublishedType, Alloc, Deleter>
+          rclcpp::experimental::SubscriptionIntraProcessBuffer<MessageT, PublishedType, Alloc, Deleter>
           >(subscription_base);
         if (nullptr == subscription) {
 
@@ -531,7 +531,7 @@ private:
           if (nullptr == ros_message_subscription) {
             throw std::runtime_error(
                     "failed to dynamic cast SubscriptionIntraProcessBase to "
-                    "SubscriptionIntraProcessBuffer<PublishedType, Alloc, Deleter>, which "
+                    "SubscriptionIntraProcessBuffer<MessageT, PublishedType, Alloc, Deleter>, which "
                     "can happen when the publisher and subscription use different "
                     "allocator types, which is not supported");
           } else {

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process.hpp
@@ -39,24 +39,24 @@ namespace experimental
 {
 
 template<
-/// MessageT::custom_type if MessageT is a TypeAdapter,
-/// otherwise just MessageT.
+  typename MessageT,
   typename SubscribedType,
   typename SubscribedTypeAlloc = std::allocator<void>,
-  typename SubscribedTypeDeleter = std::default_delete<SubscribedType>,
-  typename CallbackMessageT = SubscribedType
+  typename SubscribedTypeDeleter = std::default_delete<SubscribedType>
   >
 class SubscriptionIntraProcess
   : public SubscriptionIntraProcessBuffer<
+      MessageT,
       SubscribedType,
       SubscribedTypeAlloc,
       SubscribedTypeDeleter
     >
 {
   using SubscriptionIntraProcessBufferT = SubscriptionIntraProcessBuffer<
-  SubscribedType,
-  SubscribedTypeAlloc,
-  SubscribedTypeDeleter
+    MessageT,
+    SubscribedType,
+    SubscribedTypeAlloc,
+    SubscribedTypeDeleter
   >;
 
 public:
@@ -69,13 +69,13 @@ public:
   using BufferUniquePtr = typename SubscriptionIntraProcessBufferT::BufferUniquePtr;
 
   SubscriptionIntraProcess(
-    AnySubscriptionCallback<CallbackMessageT, SubscribedTypeAlloc> callback,
+    AnySubscriptionCallback<MessageT, SubscribedTypeAlloc> callback,
     std::shared_ptr<SubscribedTypeAlloc> allocator,
     rclcpp::Context::SharedPtr context,
     const std::string & topic_name,
     const rclcpp::QoS & qos_profile,
     rclcpp::IntraProcessBufferType buffer_type)
-  : SubscriptionIntraProcessBuffer<SubscribedType, SubscribedTypeAlloc, SubscribedTypeDeleter>(
+  : SubscriptionIntraProcessBuffer<MessageT, SubscribedType, SubscribedTypeAlloc, SubscribedTypeDeleter>(
       allocator,
       context,
       topic_name,
@@ -154,7 +154,7 @@ protected:
     shared_ptr.reset();
   }
 
-  AnySubscriptionCallback<CallbackMessageT, SubscribedTypeAlloc> any_callback_;
+  AnySubscriptionCallback<MessageT, SubscribedTypeAlloc> any_callback_;
 };
 
 }  // namespace experimental

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process.hpp
@@ -98,7 +98,7 @@ public:
   virtual ~SubscriptionIntraProcess() = default;
 
   std::shared_ptr<void>
-  take_data()
+  take_data() override
   {
     ConstMessageSharedPtr shared_msg;
     MessageUniquePtr unique_msg;
@@ -115,7 +115,7 @@ public:
     );
   }
 
-  void execute(std::shared_ptr<void> & data)
+  void execute(std::shared_ptr<void> & data) override
   {
     execute_impl<SubscribedType>(data);
   }

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process_base.hpp
@@ -15,7 +15,6 @@
 #ifndef RCLCPP__EXPERIMENTAL__SUBSCRIPTION_INTRA_PROCESS_BASE_HPP_
 #define RCLCPP__EXPERIMENTAL__SUBSCRIPTION_INTRA_PROCESS_BASE_HPP_
 
-#include <memory>
 #include <mutex>
 #include <string>
 
@@ -47,21 +46,11 @@ public:
 
   RCLCPP_PUBLIC
   size_t
-  get_number_of_ready_guard_conditions() {return 1;}
+  get_number_of_ready_guard_conditions() override {return 1;}
 
   RCLCPP_PUBLIC
   void
-  add_to_wait_set(rcl_wait_set_t * wait_set);
-
-  virtual bool
-  is_ready(rcl_wait_set_t * wait_set) = 0;
-
-  virtual
-  std::shared_ptr<void>
-  take_data() = 0;
-
-  virtual void
-  execute(std::shared_ptr<void> & data) = 0;
+  add_to_wait_set(rcl_wait_set_t * wait_set) override;
 
   virtual bool
   use_take_shared_method() const = 0;
@@ -78,10 +67,10 @@ protected:
   std::recursive_mutex reentrant_mutex_;
   rclcpp::GuardCondition gc_;
 
-private:
   virtual void
   trigger_guard_condition() = 0;
 
+private:
   std::string topic_name_;
   QoS qos_profile_;
 };

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process_buffer.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process_buffer.hpp
@@ -87,7 +87,7 @@ public:
   }
 
   bool
-  is_ready(rcl_wait_set_t * wait_set)
+  is_ready(rcl_wait_set_t * wait_set) override
   {
     (void) wait_set;
     return buffer_->has_data();
@@ -144,14 +144,14 @@ public:
   }
 
   bool
-  use_take_shared_method() const
+  use_take_shared_method() const override
   {
     return buffer_->use_take_shared_method();
   }
 
 protected:
   void
-  trigger_guard_condition()
+  trigger_guard_condition() override
   {
     this->gc_.trigger();
   }

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process_buffer.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process_buffer.hpp
@@ -39,22 +39,17 @@ namespace experimental
 
 template<
   typename MessageT,
+  typename SubscribedType,
   typename Alloc = std::allocator<void>,
-  typename Deleter = std::default_delete<MessageT>,
-  /// MessageT::custom_type if MessageT is a TypeAdapter,
-  /// otherwise just MessageT.
-  typename SubscribedT = typename rclcpp::TypeAdapter<MessageT>::custom_type,
+  typename Deleter = std::default_delete<SubscribedType>,
   /// MessageT::ros_message_type if MessageT is a TypeAdapter,
   /// otherwise just MessageT.
-  typename ROSMessageT = typename rclcpp::TypeAdapter<MessageT>::ros_message_type
+  typename ROSMessageType = typename rclcpp::TypeAdapter<SubscribedType>::ros_message_type
 >
-class SubscriptionIntraProcessBuffer : public ROSMessageIntraProcessBuffer<ROSMessageT, Alloc, Deleter>
+class SubscriptionIntraProcessBuffer : public ROSMessageIntraProcessBuffer<ROSMessageType, Alloc, Deleter>
 {
 public:
   RCLCPP_SMART_PTR_DEFINITIONS(SubscriptionIntraProcessBuffer)
-
-  using SubscribedType = SubscribedT;
-  using ROSMessageType = ROSMessageT;
 
   using SubscribedTypeAllocatorTraits = allocator::AllocRebind<SubscribedType, Alloc>;
   using SubscribedTypeAllocator = typename SubscribedTypeAllocatorTraits::allocator_type;
@@ -82,7 +77,7 @@ public:
     const std::string & topic_name,
     const rclcpp::QoS & qos_profile,
     rclcpp::IntraProcessBufferType buffer_type)
-  : ROSMessageIntraProcessBuffer<ROSMessageT, Alloc, ROSMessageTypeDeleter>(context, topic_name, qos_profile)
+  : ROSMessageIntraProcessBuffer<ROSMessageType, Alloc, ROSMessageTypeDeleter>(context, topic_name, qos_profile)
   {
     // Create the intra-process buffer.
     buffer_ = rclcpp::experimental::create_intra_process_buffer<SubscribedType, Alloc, SubscribedTypeDeleter>(
@@ -104,7 +99,7 @@ public:
 
     std::cout << "--------------Provide Intra Process Message (ConstMessageSharedPtr)" << std::endl;
 
-    if constexpr (!rclcpp::TypeAdapter<MessageT>::is_specialized::value) {
+    if constexpr (!rclcpp::TypeAdapter<SubscribedType>::is_specialized::value) {
       buffer_->add_shared(std::move(message));
       trigger_guard_condition();
     } else {
@@ -119,13 +114,13 @@ public:
   provide_intra_process_message(MessageUniquePtr message)
   {
     std::cout << "--------------Provide Intra Process Message (MessageUniquePtr)" << std::endl;
-    if constexpr (!rclcpp::TypeAdapter<MessageT>::is_specialized::value) {
+    if constexpr (!rclcpp::TypeAdapter<SubscribedType>::is_specialized::value) {
       buffer_->add_unique(std::move(message));
       trigger_guard_condition();
     } else {
       // auto ptr = SubscribedTypeAllocatorTraits::allocate(subscribed_type_allocator_, 1);
       // SubscribedTypeAllocatorTraits::construct(subscribed_type_allocator_, ptr);
-      // rclcpp::TypeAdapter<MessageT>::convert_to_custom(*message, *ptr);
+      // rclcpp::TypeAdapter<SubscribedType>::convert_to_custom(*message, *ptr);
       // buffer_->add_unique(std::unique_ptr<SubscribedType, SubscribedTypeDeleter>(ptr, subscribed_type_deleter_));
       // trigger_guard_condition();
     }

--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -512,7 +512,7 @@ protected:
       throw std::runtime_error("cannot publish msg which is a null pointer");
     }
 
-    ipm->template do_intra_process_publish<PublishedType, AllocatorT>(
+    ipm->template do_intra_process_publish<MessageT, PublishedType, AllocatorT>(
       intra_process_publisher_id_,
       std::move(msg),
       published_type_allocator_);

--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -536,7 +536,7 @@ protected:
     }
 
     return ipm->template do_intra_process_publish_and_return_shared<MessageT, T, PublishedType,
-             ROSMessageType, AllocatorT, ROSMessageTypeAllocatorTraits, ROSMessageTypeAllocator, ROSMessageTypeDeleter>(
+             ROSMessageType, AllocatorT, std::default_delete<PublishedType>, ROSMessageTypeAllocatorTraits, ROSMessageTypeAllocator, ROSMessageTypeDeleter, PublishedTypeAllocator>(
       intra_process_publisher_id_,
       std::move(msg),
       published_type_allocator_,

--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -512,10 +512,12 @@ protected:
       throw std::runtime_error("cannot publish msg which is a null pointer");
     }
 
-    ipm->template do_intra_process_publish<MessageT, PublishedType, AllocatorT>(
+    ipm->template do_intra_process_publish<MessageT, PublishedType, ROSMessageType, AllocatorT, std::default_delete<PublishedType>, ROSMessageTypeAllocatorTraits, ROSMessageTypeAllocator, ROSMessageTypeDeleter, PublishedTypeAllocator>(
       intra_process_publisher_id_,
       std::move(msg),
-      published_type_allocator_);
+      published_type_allocator_,
+      ros_message_type_allocator_,
+      ros_message_type_deleter_);
   }
 
 

--- a/rclcpp/include/rclcpp/subscription.hpp
+++ b/rclcpp/include/rclcpp/subscription.hpp
@@ -406,10 +406,10 @@ private:
   SubscriptionTopicStatisticsSharedPtr subscription_topic_statistics_{nullptr};
 
   using SubscriptionIntraProcessT = rclcpp::experimental::SubscriptionIntraProcess<
+    MessageT,
     SubscribedType,
     AllocatorT,
-    SubscribedTypeDeleter,
-    MessageT>;
+    SubscribedTypeDeleter>;
   std::shared_ptr<SubscriptionIntraProcessT> subscription_intra_process_;
 
 };


### PR DESCRIPTION
This is a very verbose PR that explicitly calls out all of the types that are being use in the intra-process code, both on the publisher side and subscriber side.  Along with that, there are a bunch of fixes in here to actually use the correct types now that they are clearer.  With this in place, we are a lot closer to having correct types, though we still need a very thorough review of the Allocator and Deleter types before everything will work.