### PR TITLE
Fix the compilation of some downstream intra-process packages.

### DIFF
--- a/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
+++ b/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
@@ -22,20 +22,24 @@
 #include <iterator>
 #include <memory>
 #include <stdexcept>
+#include <type_traits>
 #include <unordered_map>
 #include <utility>
 #include <vector>
 #include <typeinfo>
 
+#include "rosidl_runtime_cpp/traits.hpp"
+
 #include "rclcpp/allocator/allocator_deleter.hpp"
-#include "rclcpp/experimental/subscription_intra_process.hpp"
 #include "rclcpp/experimental/ros_message_intra_process_buffer.hpp"
+#include "rclcpp/experimental/subscription_intra_process.hpp"
 #include "rclcpp/experimental/subscription_intra_process_base.hpp"
 #include "rclcpp/experimental/subscription_intra_process_buffer.hpp"
 #include "rclcpp/logger.hpp"
 #include "rclcpp/logging.hpp"
 #include "rclcpp/macros.hpp"
 #include "rclcpp/publisher_base.hpp"
+#include "rclcpp/type_adapter.hpp"
 #include "rclcpp/visibility_control.hpp"
 
 namespace rclcpp
@@ -174,6 +178,7 @@ public:
    */
   template<
     typename MessageT,
+    typename T,
     typename PublishedType,
     typename ROSMessageType,
     typename Alloc,
@@ -186,7 +191,7 @@ public:
   void
   do_intra_process_publish(
     uint64_t intra_process_publisher_id,
-    std::unique_ptr<PublishedType, Deleter> message,
+    std::unique_ptr<T, Deleter> message,
     PublishedTypeAllocator & published_type_allocator,
     ROSMessageTypeAllocator & ros_message_type_allocator,
     ROSMessageTypeDeleter & ros_message_type_deleter)
@@ -207,7 +212,7 @@ public:
 
     if (sub_ids.take_ownership_subscriptions.empty()) {
       // None of the buffers require ownership, so we promote the pointer
-      std::shared_ptr<PublishedType> msg = std::move(message);
+      std::shared_ptr<T> msg = std::move(message);
 
       this->template add_shared_msg_to_buffers<MessageT, PublishedType, ROSMessageType, Alloc,
         Deleter, ROSMessageTypeAllocatorTraits, ROSMessageTypeAllocator>(
@@ -241,7 +246,7 @@ public:
       } else {
         // Construct a new shared pointer from the message
         // for the buffers that do not require ownership
-        auto shared_msg = std::allocate_shared<PublishedType, PublishedTypeAllocator>(
+        auto shared_msg = std::allocate_shared<T, PublishedTypeAllocator>(
           published_type_allocator,
           *message);
 
@@ -281,7 +286,7 @@ public:
   >
   do_intra_process_publish_and_return_shared(
     uint64_t intra_process_publisher_id,
-    std::unique_ptr<PublishedType, Deleter> message,
+    std::unique_ptr<T, Deleter> message,
     PublishedTypeAllocator & published_type_allocator,
     ROSMessageTypeAllocator & ros_message_type_allocator,
     ROSMessageTypeDeleter & ros_message_type_deleter)
@@ -300,7 +305,7 @@ public:
 
     if (sub_ids.take_ownership_subscriptions.empty()) {
       // If there are no owning, just convert to shared.
-      std::shared_ptr<PublishedType> shared_msg = std::move(message);
+      std::shared_ptr<T> shared_msg = std::move(message);
       if (!sub_ids.take_shared_subscriptions.empty()) {
         this->template add_shared_msg_to_buffers<MessageT, PublishedType, ROSMessageType, Alloc,
           Deleter, ROSMessageTypeAllocatorTraits, ROSMessageTypeAllocator>(
@@ -312,7 +317,7 @@ public:
     } else {
       // Construct a new shared pointer from the message for the buffers that
       // do not require ownership and to return.
-      auto shared_msg = std::allocate_shared<PublishedType, PublishedTypeAllocator>(
+      auto shared_msg = std::allocate_shared<T, PublishedTypeAllocator>(
         published_type_allocator,
         *message);
 
@@ -356,7 +361,7 @@ public:
   >
   do_intra_process_publish_and_return_shared(
     uint64_t intra_process_publisher_id,
-    std::unique_ptr<PublishedType, Deleter> message,
+    std::unique_ptr<T, Deleter> message,
     PublishedTypeAllocator & published_type_allocator,
     ROSMessageTypeAllocator & ros_message_type_allocator,
     ROSMessageTypeDeleter & ros_message_type_deleter)
@@ -382,7 +387,7 @@ public:
 
     if (sub_ids.take_ownership_subscriptions.empty()) {
       // If there are no owning, just convert to shared.
-      std::shared_ptr<PublishedType> shared_msg = std::move(message);
+      std::shared_ptr<T> shared_msg = std::move(message);
       if (!sub_ids.take_shared_subscriptions.empty()) {
         this->template add_shared_msg_to_buffers<MessageT, PublishedType, ROSMessageType, Alloc,
           Deleter, ROSMessageTypeAllocatorTraits, ROSMessageTypeAllocator>(
@@ -393,7 +398,7 @@ public:
     } else {
       // Construct a new shared pointer from the message for the buffers that
       // do not require ownership and to return.
-      auto shared_msg = std::allocate_shared<PublishedType, PublishedTypeAllocator>(
+      auto shared_msg = std::allocate_shared<T, PublishedTypeAllocator>(
         published_type_allocator,
         *message);
 

--- a/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
+++ b/rclcpp/include/rclcpp/experimental/intra_process_manager.hpp
@@ -186,6 +186,7 @@ public:
     typename ROSMessageTypeAllocatorTraits,
     typename ROSMessageTypeAllocator,
     typename ROSMessageTypeDeleter,
+    typename PublishedTypeAllocatorTraits,
     typename PublishedTypeAllocator
   >
   void
@@ -237,7 +238,7 @@ public:
 
         this->template add_owned_msg_to_buffers<MessageT, PublishedType, ROSMessageType, Alloc,
           Deleter, ROSMessageTypeAllocatorTraits, ROSMessageTypeAllocator, ROSMessageTypeDeleter,
-          PublishedTypeAllocator>(
+          PublishedTypeAllocatorTraits, PublishedTypeAllocator>(
           std::move(message),
           concatenated_vector,
           published_type_allocator,
@@ -257,7 +258,7 @@ public:
           ros_message_type_allocator);
         this->template add_owned_msg_to_buffers<MessageT, PublishedType, ROSMessageType, Alloc,
           Deleter, ROSMessageTypeAllocatorTraits, ROSMessageTypeAllocator, ROSMessageTypeDeleter,
-          PublishedTypeAllocator>(
+          PublishedTypeAllocatorTraits, PublishedTypeAllocator>(
           std::move(message),
           sub_ids.take_ownership_subscriptions,
           published_type_allocator,
@@ -277,6 +278,7 @@ public:
     typename ROSMessageTypeAllocatorTraits,
     typename ROSMessageTypeAllocator,
     typename ROSMessageTypeDeleter,
+    typename PublishedTypeAllocatorTraits,
     typename PublishedTypeAllocator
   >
   typename
@@ -331,7 +333,7 @@ public:
 
       this->template add_owned_msg_to_buffers<MessageT, PublishedType, ROSMessageType, Alloc,
         Deleter, ROSMessageTypeAllocatorTraits, ROSMessageTypeAllocator, ROSMessageTypeDeleter,
-        PublishedTypeAllocator>(
+        PublishedTypeAllocatorTraits, PublishedTypeAllocator>(
         std::move(message),
         sub_ids.take_ownership_subscriptions,
         published_type_allocator,
@@ -352,6 +354,7 @@ public:
     typename ROSMessageTypeAllocatorTraits,
     typename ROSMessageTypeAllocator,
     typename ROSMessageTypeDeleter,
+    typename PublishedTypeAllocatorTraits,
     typename PublishedTypeAllocator
   >
   typename
@@ -412,7 +415,7 @@ public:
 
       this->template add_owned_msg_to_buffers<MessageT, PublishedType, ROSMessageType, Alloc,
         Deleter, ROSMessageTypeAllocatorTraits, ROSMessageTypeAllocator, ROSMessageTypeDeleter,
-        PublishedTypeAllocator>(
+        PublishedTypeAllocatorTraits, PublishedTypeAllocator>(
         std::move(message),
         sub_ids.take_ownership_subscriptions,
         published_type_allocator,
@@ -537,6 +540,7 @@ private:
     typename ROSMessageTypeAllocatorTraits,
     typename ROSMessageTypeAllocator,
     typename ROSMessageTypeDeleter,
+    typename PublishedTypeAllocatorTraits,
     typename PublishedTypeAllocator
   >
   void
@@ -551,7 +555,6 @@ private:
 
     std::cout << "message has type : " << typeid(message).name() << std::endl;
 
-    using MessageAllocTraits = allocator::AllocRebind<PublishedType, Alloc>;
     using MessageUniquePtr = std::unique_ptr<PublishedType, Deleter>;
 
     for (auto it = subscription_ids.begin(); it != subscription_ids.end(); it++) {
@@ -600,8 +603,8 @@ private:
                 // Copy the message since we have additional subscriptions to serve
                 MessageUniquePtr copy_message;
                 Deleter deleter = message.get_deleter();
-                auto ptr = MessageAllocTraits::allocate(published_type_allocator, 1);
-                MessageAllocTraits::construct(published_type_allocator, ptr, *message);
+                auto ptr = PublishedTypeAllocatorTraits::allocate(published_type_allocator, 1);
+                PublishedTypeAllocatorTraits::construct(published_type_allocator, ptr, *message);
                 copy_message = MessageUniquePtr(ptr, deleter);
 
                 ros_message_subscription->provide_intra_process_message(std::move(copy_message));
@@ -617,8 +620,8 @@ private:
             // Copy the message since we have additional subscriptions to serve
             MessageUniquePtr copy_message;
             Deleter deleter = message.get_deleter();
-            auto ptr = MessageAllocTraits::allocate(published_type_allocator, 1);
-            MessageAllocTraits::construct(published_type_allocator, ptr, *message);
+            auto ptr = PublishedTypeAllocatorTraits::allocate(published_type_allocator, 1);
+            PublishedTypeAllocatorTraits::construct(published_type_allocator, ptr, *message);
             copy_message = MessageUniquePtr(ptr, deleter);
 
             subscription->provide_intra_process_data(std::move(copy_message));

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process_buffer.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process_buffer.hpp
@@ -101,7 +101,7 @@ public:
   {
     std::cout << "--------------Provide Intra Process Message (ConstMessageSharedPtr)" << std::endl;
 
-    if constexpr (!rclcpp::TypeAdapter<SubscribedType>::is_specialized::value) {
+    if constexpr (!rclcpp::TypeAdapter<MessageT>::is_specialized::value) {
       buffer_->add_shared(std::move(message));
       trigger_guard_condition();
     } else {
@@ -117,7 +117,7 @@ public:
   provide_intra_process_message(MessageUniquePtr message)
   {
     std::cout << "--------------Provide Intra Process Message (MessageUniquePtr)" << std::endl;
-    if constexpr (!rclcpp::TypeAdapter<SubscribedType>::is_specialized::value) {
+    if constexpr (!rclcpp::TypeAdapter<MessageT>::is_specialized::value) {
       buffer_->add_unique(std::move(message));
       trigger_guard_condition();
     } else {

--- a/rclcpp/include/rclcpp/publisher.hpp
+++ b/rclcpp/include/rclcpp/publisher.hpp
@@ -516,8 +516,8 @@ protected:
     }
 
     ipm->template do_intra_process_publish<MessageT, T, PublishedType, ROSMessageType, AllocatorT,
-      Deleter, ROSMessageTypeAllocatorTraits, ROSMessageTypeAllocator,
-      ROSMessageTypeDeleter, PublishedTypeAllocator>(
+      Deleter, ROSMessageTypeAllocatorTraits, ROSMessageTypeAllocator, ROSMessageTypeDeleter,
+      PublishedTypeAllocatorTraits, PublishedTypeAllocator>(
       intra_process_publisher_id_,
       std::move(msg),
       published_type_allocator_,
@@ -542,7 +542,7 @@ protected:
     return ipm->template do_intra_process_publish_and_return_shared<MessageT, T, PublishedType,
              ROSMessageType, AllocatorT, Deleter,
              ROSMessageTypeAllocatorTraits, ROSMessageTypeAllocator, ROSMessageTypeDeleter,
-             PublishedTypeAllocator>(
+             PublishedTypeAllocatorTraits, PublishedTypeAllocator>(
       intra_process_publisher_id_,
       std::move(msg),
       published_type_allocator_,

--- a/rclcpp/include/rclcpp/subscription.hpp
+++ b/rclcpp/include/rclcpp/subscription.hpp
@@ -276,7 +276,7 @@ public:
 
   /// Take the next message from the inter-process subscription.
   /**
-   * This verison takes a SubscribedType which is different frmo the
+   * This version takes a SubscribedType which is different from the
    * ROSMessageType when a rclcpp::TypeAdapter is in used.
    *
    * \sa take(ROSMessageType &, rclcpp::MessageInfo &)


### PR DESCRIPTION
In particular, the fixes in here make it so that the tlsf_cpp
package can now compile.  What's going on in this PR is that
we are being more careful with using the template type that
the user passed in, and passing that along as appropriate.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>