### PR TITLE
Fix the test for any_subscription_callback.

### DIFF
--- a/rclcpp/test/rclcpp/CMakeLists.txt
+++ b/rclcpp/test/rclcpp/CMakeLists.txt
@@ -63,13 +63,13 @@ if(TARGET test_any_service_callback)
   )
   target_link_libraries(test_any_service_callback ${PROJECT_NAME})
 endif()
-# ament_add_gtest(test_any_subscription_callback test_any_subscription_callback.cpp)
-# if(TARGET test_any_subscription_callback)
-#   ament_target_dependencies(test_any_subscription_callback
-#     "test_msgs"
-#   )
-#   target_link_libraries(test_any_subscription_callback ${PROJECT_NAME})
-# endif()
+ament_add_gtest(test_any_subscription_callback test_any_subscription_callback.cpp)
+if(TARGET test_any_subscription_callback)
+  ament_target_dependencies(test_any_subscription_callback
+    "test_msgs"
+  )
+  target_link_libraries(test_any_subscription_callback ${PROJECT_NAME})
+endif()
 ament_add_gtest(test_client test_client.cpp)
 if(TARGET test_client)
   ament_target_dependencies(test_client


### PR DESCRIPTION
In particular, change it so that the tests for TypeAdaptation
with any_subscription_callback always pass the custom type
to dispatch_intra_process().  That means that when using
TypeAdaptation, it is not possible to call dispatch_intra_process()
with the ROS message type.  But since this is a low-level
interface, this should be fine; the public-facing APIs handle
this case for us.

This also requires us to remove the test for inter-process
publishing with type adaptation.  That's because we didn't change
the signature of AnySubscriptionCallback::dispath() to take
in the custom type, so it always expects the ROS message type.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>