### PR TITLE
Fix the intra-process tests

### DIFF
--- a/rclcpp/include/rclcpp/experimental/ros_message_intra_process_buffer.hpp
+++ b/rclcpp/include/rclcpp/experimental/ros_message_intra_process_buffer.hpp
@@ -15,16 +15,13 @@
 #ifndef RCLCPP__EXPERIMENTAL__ROS_MESSAGE_INTRA_PROCESS_BUFFER_HPP_
 #define RCLCPP__EXPERIMENTAL__ROS_MESSAGE_INTRA_PROCESS_BUFFER_HPP_
 
-#include <functional>
-#include <map>
 #include <memory>
-#include <stdexcept>
 #include <string>
-#include <utility>
 
 #include "rcl/error_handling.h"
 
 #include "rclcpp/any_subscription_callback.hpp"
+#include "rclcpp/context.hpp"
 #include "rclcpp/experimental/subscription_intra_process_base.hpp"
 #include "tracetools/tracetools.h"
 

--- a/rclcpp/test/rclcpp/CMakeLists.txt
+++ b/rclcpp/test/rclcpp/CMakeLists.txt
@@ -135,24 +135,24 @@ ament_add_gtest(
 if(TARGET test_future_return_code)
   target_link_libraries(test_future_return_code ${PROJECT_NAME})
 endif()
-# ament_add_gmock(test_intra_process_manager test_intra_process_manager.cpp)
-# if(TARGET test_intra_process_manager)
-#   ament_target_dependencies(test_intra_process_manager
-#     "rcl"
-#     "rcl_interfaces"
-#     "rmw"
-#     "rosidl_runtime_cpp"
-#     "rosidl_typesupport_cpp"
-#   )
-#   target_link_libraries(test_intra_process_manager ${PROJECT_NAME})
-# endif()
-# ament_add_gmock(test_intra_process_manager_with_allocators test_intra_process_manager_with_allocators.cpp)
-# if(TARGET test_intra_process_manager_with_allocators)
-#   ament_target_dependencies(test_intra_process_manager_with_allocators
-#     "test_msgs"
-#   )
-#   target_link_libraries(test_intra_process_manager_with_allocators ${PROJECT_NAME})
-# endif()
+ament_add_gmock(test_intra_process_manager test_intra_process_manager.cpp)
+if(TARGET test_intra_process_manager)
+  ament_target_dependencies(test_intra_process_manager
+    "rcl"
+    "rcl_interfaces"
+    "rmw"
+    "rosidl_runtime_cpp"
+    "rosidl_typesupport_cpp"
+  )
+  target_link_libraries(test_intra_process_manager ${PROJECT_NAME})
+endif()
+ament_add_gmock(test_intra_process_manager_with_allocators test_intra_process_manager_with_allocators.cpp)
+if(TARGET test_intra_process_manager_with_allocators)
+  ament_target_dependencies(test_intra_process_manager_with_allocators
+    "test_msgs"
+  )
+  target_link_libraries(test_intra_process_manager_with_allocators ${PROJECT_NAME})
+endif()
 ament_add_gtest(test_ring_buffer_implementation test_ring_buffer_implementation.cpp)
 if(TARGET test_ring_buffer_implementation)
   ament_target_dependencies(test_ring_buffer_implementation

--- a/rclcpp/test/rclcpp/test_intra_process_manager.cpp
+++ b/rclcpp/test/rclcpp/test_intra_process_manager.cpp
@@ -246,6 +246,18 @@ public:
     buffer->add(std::move(msg));
   }
 
+  void
+  provide_intra_process_data(std::shared_ptr<const MessageT> msg)
+  {
+    buffer->add(msg);
+  }
+
+  void
+  provide_intra_process_data(std::unique_ptr<MessageT> msg)
+  {
+    buffer->add(std::move(msg));
+  }
+
   std::uintptr_t
   pop()
   {


### PR DESCRIPTION
This required a small patch to ros_message_intra_process_buffer, along with a couple of fixes to test_intra_process_manager.cpp.  That's about it.

This currently builds on #13, so will have to be rebased after #13 is in.