### PR TITLE
Fixes that came out of macOS.

### DIFF
--- a/rclcpp/include/rclcpp/any_subscription_callback.hpp
+++ b/rclcpp/include/rclcpp/any_subscription_callback.hpp
@@ -817,6 +817,11 @@ public:
     // Dispatch.
     std::visit(
       [&message, &message_info, this](auto && callback) {
+        // clang complains that 'this' lambda capture is unused, which is true
+        // in *some* specializations of this template, but not others.  Just
+        // quiet it down.
+        (void)this;
+
         using T = std::decay_t<decltype(callback)>;
         static constexpr bool is_ta = rclcpp::TypeAdapter<MessageT>::is_specialized::value;
 

--- a/rclcpp/include/rclcpp/experimental/ros_message_intra_process_buffer.hpp
+++ b/rclcpp/include/rclcpp/experimental/ros_message_intra_process_buffer.hpp
@@ -38,8 +38,6 @@ template<
 class ROSMessageIntraProcessBuffer : public SubscriptionIntraProcessBase
 {
 public:
-  RCLCPP_SMART_PTR_DEFINITIONS(ROSMessageIntraProcessBuffer)
-
   using ROSMessageTypeAllocatorTraits = allocator::AllocRebind<RosMessageT, Alloc>;
   using ROSMessageTypeAllocator = typename ROSMessageTypeAllocatorTraits::allocator_type;
   using ROSMessageTypeDeleter = allocator::Deleter<ROSMessageTypeAllocator, RosMessageT>;

--- a/rclcpp/include/rclcpp/experimental/subscription_intra_process_buffer.hpp
+++ b/rclcpp/include/rclcpp/experimental/subscription_intra_process_buffer.hpp
@@ -115,7 +115,7 @@ public:
   }
 
   void
-  provide_intra_process_message(ConstMessageSharedPtr message)
+  provide_intra_process_message(ConstMessageSharedPtr message) override
   {
     if constexpr (std::is_same<SubscribedType, ROSMessageType>::value) {
       buffer_->add_shared(std::move(message));
@@ -127,7 +127,7 @@ public:
   }
 
   void
-  provide_intra_process_message(MessageUniquePtr message)
+  provide_intra_process_message(MessageUniquePtr message) override
   {
     if constexpr (std::is_same<SubscribedType, ROSMessageType>::value) {
       buffer_->add_unique(std::move(message));

--- a/rclcpp/test/rclcpp/test_intra_process_manager.cpp
+++ b/rclcpp/test/rclcpp/test_intra_process_manager.cpp
@@ -22,6 +22,7 @@
 
 #define RCLCPP_BUILDING_LIBRARY 1
 #include "rclcpp/allocator/allocator_common.hpp"
+#include "rclcpp/context.hpp"
 #include "rclcpp/macros.hpp"
 #include "rclcpp/qos.hpp"
 #include "rmw/types.h"
@@ -194,9 +195,14 @@ class SubscriptionIntraProcessBase
 public:
   RCLCPP_SMART_PTR_ALIASES_ONLY(SubscriptionIntraProcessBase)
 
-  explicit SubscriptionIntraProcessBase(rclcpp::QoS qos = rclcpp::QoS(10))
-  : qos_profile(qos), topic_name("topic")
-  {}
+  explicit SubscriptionIntraProcessBase(
+    rclcpp::Context::SharedPtr context,
+    const std::string & topic = "topic",
+    rclcpp::QoS qos = rclcpp::QoS(10))
+  : qos_profile(qos), topic_name(topic)
+  {
+    (void)context;
+  }
 
   virtual ~SubscriptionIntraProcessBase() {}
 
@@ -212,11 +218,11 @@ public:
   const char *
   get_topic_name()
   {
-    return topic_name;
+    return topic_name.c_str();
   }
 
   rclcpp::QoS qos_profile;
-  const char * topic_name;
+  std::string topic_name;
 };
 
 template<
@@ -231,7 +237,7 @@ public:
   RCLCPP_SMART_PTR_DEFINITIONS(SubscriptionIntraProcessBuffer)
 
   explicit SubscriptionIntraProcessBuffer(rclcpp::QoS qos)
-  : SubscriptionIntraProcessBase(qos), take_shared_method(false)
+  : SubscriptionIntraProcessBase(nullptr, "topic", qos), take_shared_method(false)
   {
     buffer = std::make_unique<rclcpp::experimental::buffers::mock::IntraProcessBuffer<MessageT>>();
   }


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

All of the fixes here are things that clang complained about while trying to compile this branch.  After these fixes, macOS builds using clang are entirely clean.

I recompiled everything on Linux with these changes, and that seems to be happy as well.